### PR TITLE
Discord button

### DIFF
--- a/src/app/views/dashboard/Settings.jsx
+++ b/src/app/views/dashboard/Settings.jsx
@@ -163,7 +163,8 @@ const Settings = () => {
           variant="outlined"
           onClick={() =>
             window.open(
-              `${discordUrl}${discord ? "remove" : "join"}?user_id=${uid}`
+              `${discordUrl}${discord ? "remove" : "join"}?user_id=${uid}`,
+              "_self"
             )
           }
         >


### PR DESCRIPTION
Add a Discord button within `<Settings/>` of the admin console. Button says 'Fetching...' before `user` data has been retrieved. When loaded and if the `discord` field is falsy, the button says 'Connect'. If truthy, it says 'Disconnect'. 

Clicking on the button will trigger a redirect to the Discord app hosted on Heroku and built by @oussama1598. Depending on the state of the button, the app will either `join` or `remove` the users Discord from Firestore. A role will be assigned by the app when joining (after user logs in).

_**Note:**_ This branch has not been tested as the Discord app is not yet running. If it doesn't work and needs to be tweaked, an subsequent branch with fixes will be created and merged to main.